### PR TITLE
Prevent publishing all content items during creation

### DIFF
--- a/src/Alloy.Sample/modules/_protected/advanced-cms-forms/1.0.0/Scripts/editors/content-area-editor.js
+++ b/src/Alloy.Sample/modules/_protected/advanced-cms-forms/1.0.0/Scripts/editors/content-area-editor.js
@@ -27,6 +27,11 @@ define([
             if (this.advancedFormsOptions.inlineEditing) {
                 updateInlineEditCommands(this);
             }
+        },
+        _getCreateNewBlockCommand: function () {
+            var command = this.inherited(arguments);
+            command.set("autoPublish", true);
+            return command;
         }
     });
 });

--- a/src/Alloy.Sample/modules/_protected/advanced-cms-forms/1.0.0/Scripts/editors/content-area.js
+++ b/src/Alloy.Sample/modules/_protected/advanced-cms-forms/1.0.0/Scripts/editors/content-area.js
@@ -41,6 +41,11 @@ define([
                 propertyName: this.name,
                 value: value
             });
+        },
+        _getCreateNewBlockCommand: function () {
+            var command = this.inherited(arguments);
+            command.set("autoPublish", true);
+            return command;
         }
     });
 });

--- a/src/Alloy.Sample/modules/_protected/advanced-cms-forms/1.0.0/Scripts/initializer.js
+++ b/src/Alloy.Sample/modules/_protected/advanced-cms-forms/1.0.0/Scripts/initializer.js
@@ -45,12 +45,6 @@ define([
                 original.apply(this, arguments);
             }
 
-            var originalAutoPublishSetter = CreateContentViewModel.prototype._autoPublishSetter;
-            CreateContentViewModel.prototype._autoPublishSetter = function () {
-                originalAutoPublishSetter.apply(this, arguments);
-                this.autoPublish = true;
-            }
-
             var originalValidate = ChoiceItemWithSelection.prototype.validate;
             ChoiceItemWithSelection.prototype.validate = function (ddl, data) {
                 originalValidate.apply(this, arguments);


### PR DESCRIPTION
autoPublish flag should only be set inside the CreateContentFromSelector
We need to override the _getCreateNewBlockCommand method because Forms'
editors do not set the autoPublish flag themselves.

Closes #5